### PR TITLE
【修改】rt_cm_backtrace_init 接口添加重复初始化判断

### DIFF
--- a/cmb_port.c
+++ b/cmb_port.c
@@ -140,12 +140,20 @@ RT_WEAK void assert_hook(const char* ex, const char* func, rt_size_t line) {
 }
 
 int rt_cm_backtrace_init(void) {
+    static rt_bool_t is_init = RT_FALSE;
+
+    if (is_init)
+    {
+        return 0;
+    }
+
     cm_backtrace_init("rtthread","1.0","1.0");
     
     rt_hw_exception_install(exception_hook);
 
     rt_assert_set_hook(assert_hook);
     
+    is_init = RT_TRUE;
     return 0;
 }
 INIT_DEVICE_EXPORT(rt_cm_backtrace_init);


### PR DESCRIPTION
Signed-off-by: chenyong <chenyong@rt-thread.com>