### PR TITLE
更新port文件,与 rt_kprintf_threadsafe兼容

### DIFF
--- a/cmb_port.c
+++ b/cmb_port.c
@@ -86,7 +86,7 @@ void rt_cm_backtrace_exception_hook(void *context)
     uint32_t lr;
     uint32_t *other_info_sp = 0;
 
-    rt_enter_critical();
+    rt_interrupt_enter();
 
 #ifdef RT_USING_FINSH
     extern long list_thread(void);
@@ -178,6 +178,8 @@ void rt_cm_backtrace_exception_hook(void *context)
     cmb_println("==============================================================");
 
     cmb_println("Current system tick: %ld", rt_tick_get());
+
+    rt_interrupt_leave();
 }
 
 #else
@@ -196,8 +198,8 @@ void rt_cm_backtrace_exception_hook(void *context)
 #else
 #define EXC_RETURN_MASK                0x0000000F // Bits[31:5]
 #endif
-        
-    rt_enter_critical();
+
+    rt_interrupt_enter();
 
 #ifdef RT_USING_FINSH
     extern long list_thread(void);
@@ -230,13 +232,14 @@ void rt_cm_backtrace_exception_hook(void *context)
     cm_backtrace_fault(lr, cmb_get_sp() + sizeof(uint32_t) * CMB_SP_WORD_OFFSET);
 
     cmb_println("Current system tick: %ld", rt_tick_get());
+    rt_interrupt_leave();
 }
 
 #endif
 
 void rt_cm_backtrace_assert_hook(const char* ex, const char* func, rt_size_t line)
 {
-    rt_enter_critical();
+    rt_interrupt_enter();
 
 #ifdef RT_USING_FINSH
     extern long list_thread(void);
@@ -249,6 +252,8 @@ void rt_cm_backtrace_assert_hook(const char* ex, const char* func, rt_size_t lin
     cm_backtrace_assert(cmb_get_sp());
 
     cmb_println("Current system tick: %ld", rt_tick_get());
+
+    rt_interrupt_leave();
 }
 
 RT_WEAK rt_err_t exception_hook(void *context) {
@@ -277,7 +282,7 @@ int rt_cm_backtrace_init(void) {
         return 0;
     }
 
-    cm_backtrace_init("rtthread","1.0","1.0");
+    cm_backtrace_init("rt-thread","1.0","1.0");
     
     rt_hw_exception_install(exception_hook);
 


### PR DESCRIPTION
- 更新port文件,与 rt_kprintf_threadsafe兼容
- 详细看这里 > https://github.com/armink-rtt-pkgs/CmBacktrace/issues/13
- 启用 rt_kprintf_threadsafe后,cmb无法正常打印错误信息
- 原因大致为 rt_kprintf_threadsafe中判断不在中断或者在线程中,会创建互斥量保护线程.
- 而cmb原来用rt_enter_critical()无法被识别为中断中,将会创建互斥量.
- 互斥量中将会触发RT_DEBUG_SCHEDULER_AVAILABLE
- 改为使用中断保护,本来也是进入了错误中断触发的

- 在STM32F4和STM32F7中复现问题,更新代码都得到解决