### PR TITLE
fix:gcc编译器对于cmb_println的警告

### DIFF
--- a/cm_backtrace.c
+++ b/cm_backtrace.c
@@ -269,7 +269,7 @@ static void dump_stack(uint32_t stack_start_addr, size_t stack_size, uint32_t *s
     }
     cmb_println(print_info[PRINT_THREAD_STACK_INFO]);
     for (; (uint32_t) stack_pointer < stack_start_addr + stack_size && deep; stack_pointer++, deep--) {
-        cmb_println("  addr: %08x    data: %08x", stack_pointer, *stack_pointer);
+        cmb_println("  addr: %08lx    data: %08lx", (uint32_t)stack_pointer, *stack_pointer);
     }
     cmb_println("====================================");
 }
@@ -430,7 +430,7 @@ void cm_backtrace_assert(uint32_t sp) {
 
     CMB_ASSERT(init_ok);
 
-    cmb_println("");
+    cmb_println(" ");
     cm_backtrace_firmware_info();
 
 #ifdef CMB_USING_OS_PLATFORM
@@ -617,7 +617,7 @@ void cm_backtrace_fault(uint32_t fault_handler_lr, uint32_t fault_handler_sp) {
 
     on_fault = true;
 
-    cmb_println("");
+    cmb_println(" ");
     cm_backtrace_firmware_info();
 
 #ifdef CMB_USING_OS_PLATFORM
@@ -650,7 +650,7 @@ void cm_backtrace_fault(uint32_t fault_handler_lr, uint32_t fault_handler_sp) {
 #ifdef CMB_USING_DUMP_STACK_INFO
     /* check stack overflow */
     if (stack_pointer < stack_start_addr || stack_pointer > stack_start_addr + stack_size) {
-        cmb_println("stack_pointer: 0x%08x, stack_start_addr: 0x%08x, stack_end_addr: 0x%08x", stack_pointer, stack_start_addr,
+        cmb_println("stack_pointer: 0x%08lx, stack_start_addr: 0x%08lx, stack_end_addr: 0x%08lx", (uint32_t)stack_pointer, stack_start_addr,
             stack_start_addr + stack_size);
         stack_is_overflow = true;
 #if (CMB_OS_PLATFORM_TYPE == CMB_OS_PLATFORM_RTT)


### PR DESCRIPTION
error: format '%x' expects argument of type 'unsigned int', but argument 2 has type 'uint32_t *' {aka 'long unsigned int *'} 
error: zero-length gnu_printf format string [-Werror=format-zero-length]